### PR TITLE
testing: Fix flaky ExampleZipExtra.  Closes: #1.

### DIFF
--- a/zipextra_example_test.go
+++ b/zipextra_example_test.go
@@ -53,7 +53,10 @@ func ExampleZipExtra() {
 		case zipextra.ExtraFieldUnixN:
 			unix, _ := field.InfoZIPNewUnix()
 			fmt.Printf("UID: %d, GID: %d\n", unix.Uid, unix.Gid)
-
+		}
+	}
+	for id, field := range fields {
+		switch id {
 		case zipextra.ExtraFieldUCom:
 			ucom, _ := field.InfoZIPUnicodeComment()
 			fmt.Printf("Comment: %s\n", ucom.Comment)


### PR DESCRIPTION
I looked at the code, and found this:

```
        // print extra field information
        for id, field := range fields {
                switch id {
                case zipextra.ExtraFieldUnixN:
                        unix, _ := field.InfoZIPNewUnix()
                        fmt.Printf("UID: %d, GID: %d\n", unix.Uid, unix.Gid)

                case zipextra.ExtraFieldUCom:
                        ucom, _ := field.InfoZIPUnicodeComment()
                        fmt.Printf("Comment: %s\n", ucom.Comment)
                }
        }
        // Output:
        // UID: 1000, GID: 1000
        // Comment: Hello, 世界
```

This pull request turns this into the following so that the output is predictable and not random depending on which field was printed first.  Maybe there are better ways to resolve this, but this seems to resolve the problem at least and I will use the patch in our Debian packaging.

```
        // print extra field information
        for id, field := range fields {
                switch id {
                case zipextra.ExtraFieldUnixN:
                        unix, _ := field.InfoZIPNewUnix()
                        fmt.Printf("UID: %d, GID: %d\n", unix.Uid, unix.Gid)
                }
        }
        for id, field := range fields {
                switch id {
                case zipextra.ExtraFieldUCom:
                        ucom, _ := field.InfoZIPUnicodeComment()
                        fmt.Printf("Comment: %s\n", ucom.Comment)
                }
        }
        // Output:
        // UID: 1000, GID: 1000
        // Comment: Hello, 世界
```

If you merge this, please also consider tagging a new release version!

Thanks,
Simon